### PR TITLE
HOTFIX: Documentation uses path to wrong theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Note that the git repo already has a `.lando.yml` file so you shouldn't run `lan
 
    Note (don't run these commands): per .lando.yml and .lando.local.yml, when `lando start` is run for the first time and whenever `lando rebuild` is run, the following commands are run inside the container:
    * `composer install` for the project
-   * `npm install` in web/themes/drupaleurope
-   * `npm run build` in web/themes/drupaleurope to compile the theme
+   * `npm install` in web/themes/drupalnyc
+   * `npm run build` in web/themes/drupalnyc to compile the theme
 
 7. For a fresh Drupal installation that takes advantage of all the configuration that has already been done, install from config:
 


### PR DESCRIPTION
This is confusing because `web/themes/drupaleurope` exists in the repo.